### PR TITLE
Working Cowsay

### DIFF
--- a/8_Lab9_Terraform/Docker/Dockerfile
+++ b/8_Lab9_Terraform/Docker/Dockerfile
@@ -9,7 +9,7 @@ RUN chown cloudsdk:cloudsdk /app
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 RUN chmod 700 get_helm.sh 
 RUN ./get_helm.sh 
-#USER cloudsdk
+USER cloudsdk
 WORKDIR /app 
 RUN git clone https://github.com/GoogleCloudPlatform/gke-security-scenarios-demo
 RUN sed -i 's/f1-micro/n1-standard-1/g' /app/gke-security-scenarios-demo/terraform/variables.tf

--- a/8_Lab9_Terraform/Docker/Dockerfile
+++ b/8_Lab9_Terraform/Docker/Dockerfile
@@ -9,7 +9,9 @@ RUN chown cloudsdk:cloudsdk /app
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 RUN chmod 700 get_helm.sh 
 RUN ./get_helm.sh 
-USER cloudsdk
+#USER cloudsdk
+#Running as root causes issues if you have code that generates keys based on the local user
+#Running as cloudsdk causes issues if you want to mount Docker container locally (docker run -v /var/run.docker.sock:/var/run/docker.sock
 WORKDIR /app 
 RUN git clone https://github.com/GoogleCloudPlatform/gke-security-scenarios-demo
 RUN sed -i 's/f1-micro/n1-standard-1/g' /app/gke-security-scenarios-demo/terraform/variables.tf

--- a/9_Prep_Beginner_K8s/orchestration/README.md
+++ b/9_Prep_Beginner_K8s/orchestration/README.md
@@ -1,0 +1,5 @@
+#Kubernetes for Beginners lab
+
+Adapted from https://dev.to/ken_mwaura1/deploying-web-applications-on-kubernetes-a-beginners-guide-4ano
+
+

--- a/9_Prep_Beginner_K8s/orchestration/README.md
+++ b/9_Prep_Beginner_K8s/orchestration/README.md
@@ -1,5 +1,68 @@
 #Kubernetes for Beginners lab
 
+Jenafae asked some questions about the lab that demonstrates Kubernetes deployments.
+
+From the issue that was provided, I believe the solution relates to having to get credentials from gcloud cli for kubectl:
+
+```
+gcloud container clusters get-credentials <clustername>
+```
+
+In any case I walked through the lab that was referenced to provide some additional insight:
+
 Adapted from https://dev.to/ken_mwaura1/deploying-web-applications-on-kubernetes-a-beginners-guide-4ano
 
+You'll see here code copied from the blog above, with some inline notes on how to take it further.
 
+The lab doesn't go far enough to be able to see the application container in the deployment manifest actually render on the web.
+
+We learned about how to do that last week, and some of that may have been lost in the noise of the bugs that were encountered:
+
+Here is one lab example on where they built a Loadbalancer which served to the Internet:
+
+https://github.com/GoogleCloudPlatform/gke-security-scenarios-demo/blob/master/terraform/modules/instance/manifests/nginx.yaml#L63
+
+Week 7 (7.3) also had some examples
+https://github.com/GoogleCloudPlatform/training-data-analyst/tree/master/courses/ak8s/v1.1/Deployments
+https://github.com/GoogleCloudPlatform/training-data-analyst/blob/master/courses/ak8s/v1.1/Deployments/service-nginx.yaml
+
+Ultimately Kubernetes API Documentation for Deployments, Services, and other resource types is the authoritative source for what you'll need to accomplish your specific use case.
+
+You'll see inline comments in the yaml of this repository that might help.
+
+# Quick run
+
+1) Create cluster
+2) Get credentials
+
+```
+gcloud congtainer clusters get-credentials <clustername>
+```
+
+```
+kubectl apply -f cowsay.yaml
+```
+
+```
+kubectl get deployments
+```
+
+```
+kubectl apply -f cowsay-service.yaml
+```
+
+```
+kubectl get services 
+``` 
+
+```
+kubectl apply -f cowsay-service-ext.yaml
+``` 
+
+```
+kubectl get services 
+``` 
+
+```
+kubectl delete service cowsay-service 
+``` 

--- a/9_Prep_Beginner_K8s/orchestration/cowsay-service-ext.yaml
+++ b/9_Prep_Beginner_K8s/orchestration/cowsay-service-ext.yaml
@@ -1,4 +1,4 @@
-#
+#     Lab questions response: 2024-06-19
 #     Remember from the gke-security-scenario demo we created a load balancer? 
 #     https://github.com/GoogleCloudPlatform/gke-security-scenarios-demo/blob/master/terraform/modules/instance/manifests/nginx.yaml#L63
 #     

--- a/9_Prep_Beginner_K8s/orchestration/cowsay-service-ext.yaml
+++ b/9_Prep_Beginner_K8s/orchestration/cowsay-service-ext.yaml
@@ -1,15 +1,3 @@
-  apiVersion: v1
-  kind: Service
-  metadata:
-    name: cowsay-service
-  spec:
-    externalTrafficPolicy: Cluster 
-    selector:
-      app: cowsay
-      type: NodePort 
-    ports:
-      - port: 80
-        targetPort: 80
 #
 #     Remember from the gke-security-scenario demo we created a load balancer? 
 #     https://github.com/GoogleCloudPlatform/gke-security-scenarios-demo/blob/master/terraform/modules/instance/manifests/nginx.yaml#L63
@@ -17,7 +5,7 @@
 #     The current lab says vaguely to update the deployment or expose it via "NodePort"
 #     https://dev.to/ken_mwaura1/deploying-web-applications-on-kubernetes-a-beginners-guide-4ano
 #
-#     type: Loadbalancer is another type like "NodePort" I've added that modification below so you can at least see the page render
+#     type: Loadbalancer is another type like "NodePort" I've added that modification below which serves the deployment so the page can render 
 #     If you run: kubectl apply -f cowsay-service.yaml 
 #     and then: kubectl get services
 #     You'll get output that now shows the external ip 
@@ -27,4 +15,16 @@
 #     
 #     Visit http://34.aaa.bbb.ccc in a web browser and you'll see a web page for docker/getting-started which was the deployment image 
 #     First, uncomment the type: Loadbalancer line at the top. Yaml is a format that requires proper indentation.
-#     so type: must line up right under "app:" with the a in app stacked in the same column as the t in type 
+#     so type: must line up right above "selector:" with the s in selector stacked in the same column below the  t in type 
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: cowsay-service
+  spec:
+    externalTrafficPolicy: Cluster 
+    type: LoadBalancer 
+    selector:
+      app: cowsay
+    ports:
+      - port: 80
+        targetPort: 80

--- a/9_Prep_Beginner_K8s/orchestration/cowsay-service-ext.yaml
+++ b/9_Prep_Beginner_K8s/orchestration/cowsay-service-ext.yaml
@@ -1,0 +1,30 @@
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: cowsay-service
+  spec:
+    externalTrafficPolicy: Cluster 
+    selector:
+      app: cowsay
+      type: NodePort 
+    ports:
+      - port: 80
+        targetPort: 80
+#
+#     Remember from the gke-security-scenario demo we created a load balancer? 
+#     https://github.com/GoogleCloudPlatform/gke-security-scenarios-demo/blob/master/terraform/modules/instance/manifests/nginx.yaml#L63
+#     
+#     The current lab says vaguely to update the deployment or expose it via "NodePort"
+#     https://dev.to/ken_mwaura1/deploying-web-applications-on-kubernetes-a-beginners-guide-4ano
+#
+#     type: Loadbalancer is another type like "NodePort" I've added that modification below so you can at least see the page render
+#     If you run: kubectl apply -f cowsay-service.yaml 
+#     and then: kubectl get services
+#     You'll get output that now shows the external ip 
+#     
+#     NAME             TYPE           CLUSTER-IP       EXTERNAL-IP    PORT(S)        AGE
+#     cowsay-service   LoadBalancer   34.xxx.yyy.zzz   34.aaa.bbb.ccc 80:32081/TCP   18m
+#     
+#     Visit http://34.aaa.bbb.ccc in a web browser and you'll see a web page for docker/getting-started which was the deployment image 
+#     First, uncomment the type: Loadbalancer line at the top. Yaml is a format that requires proper indentation.
+#     so type: must line up right under "app:" with the a in app stacked in the same column as the t in type 

--- a/9_Prep_Beginner_K8s/orchestration/cowsay-service.yaml
+++ b/9_Prep_Beginner_K8s/orchestration/cowsay-service.yaml
@@ -1,8 +1,10 @@
- apiVersion: v1
+  apiVersion: v1
   kind: Service
   metadata:
     name: cowsay-service
   spec:
+#    externalTrafficPolicy: Cluster 
+#    type: LoadBalancer 
     selector:
       app: cowsay
     ports:

--- a/9_Prep_Beginner_K8s/orchestration/cowsay-service.yaml
+++ b/9_Prep_Beginner_K8s/orchestration/cowsay-service.yaml
@@ -1,0 +1,10 @@
+ apiVersion: v1
+  kind: Service
+  metadata:
+    name: cowsay-service
+  spec:
+    selector:
+      app: cowsay
+    ports:
+      - port: 80
+        targetPort: 80

--- a/9_Prep_Beginner_K8s/orchestration/cowsay.yaml
+++ b/9_Prep_Beginner_K8s/orchestration/cowsay.yaml
@@ -1,0 +1,19 @@
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: cowsay
+  spec:
+    replicas: 3
+    selector:
+      matchLabels:
+        app: cowsay
+    template:
+      metadata:
+        labels:
+          app: cowsay
+      spec:
+        containers:
+        - name: cowsay
+          image: docker/getting-started
+          ports:
+          - containerPort: 80

--- a/9_Prep_Beginner_K8s/orchestration/my-webapp-deployment.yaml
+++ b/9_Prep_Beginner_K8s/orchestration/my-webapp-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+  apiVersion: apps/v1
   kind: Deployment
   metadata:
     name: my-webapp

--- a/9_Prep_Beginner_K8s/orchestration/my-webapp-deployment.yaml
+++ b/9_Prep_Beginner_K8s/orchestration/my-webapp-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: my-webapp
+  spec:
+    replicas: 3
+    selector:
+      matchLabels:
+        app: my-webapp
+    template:
+      metadata:
+        labels:
+          app: my-webapp
+      spec:
+        containers:
+        - name: my-webapp
+          image: nginx:1.7.9
+          ports:
+          - containerPort: 80

--- a/9_Prep_Beginner_K8s/orchestration/my-webapp-service.yaml
+++ b/9_Prep_Beginner_K8s/orchestration/my-webapp-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+  apiVersion: v1
   kind: Service
   metadata:
     name: my-webapp-service

--- a/9_Prep_Beginner_K8s/orchestration/my-webapp-service.yaml
+++ b/9_Prep_Beginner_K8s/orchestration/my-webapp-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+  kind: Service
+  metadata:
+    name: my-webapp-service
+  spec:
+    selector:
+      app: my-webapp
+    type: NodePort  
+    ports:
+      - port: 80
+        targetPort: 80
+        nodePort: 30007


### PR DESCRIPTION
I provided some instruction on how you can get more learning out of the [blog](https://dev.to/ken_mwaura1/deploying-web-applications-on-kubernetes-a-beginners-guide-4ano) referenced by Jenafae:
https://dev.to/ken_mwaura1/deploying-web-applications-on-kubernetes-a-beginners-guide-4ano 

```kubectl apply -f cowsay-service-ext.yaml``` is the command which will tell kubernetes to give you an external IP for a service which exposes the pod that hosts docker/getting-started container (not cowsay, which is a thing). 

When it works it'll look something like this:

<img width="647" alt="image" src="https://github.com/phydroxide/ensign/assets/31145228/a0a95807-878a-4614-9b07-e82b49992e06">


And the site will look like this:


![image](https://github.com/phydroxide/ensign/assets/31145228/2608fb84-2c1b-447c-801c-bd109d0e761a)
