### PR TITLE
Certificates

### DIFF
--- a/10_Certificates/README.md
+++ b/10_Certificates/README.md
@@ -94,7 +94,16 @@ I also need an [External Applcation Load Balancer](https://console.cloud.google.
 Load Balancers allow the creation of a certificate. You can Generate the CSR yourself, have an authority issue you a cert and import it, or let Google Manage it for you.
 
 You'll need to create a DNS record to validate the certificate challenge to prove you own the domain. 
+![image](https://github.com/phydroxide/ensign/assets/31145228/ac843d64-895f-4518-a26b-48423c0707a5)
 
+It will ask you to create DNS authorization
+![image](https://github.com/phydroxide/ensign/assets/31145228/9e479fec-9b8f-4388-b06d-58050ac08680)
+
+
+![image](https://github.com/phydroxide/ensign/assets/31145228/3a4a8fa5-7731-4abb-9c18-0f08d49ce130)
+
+
+You'll set up the appropriate DNS record in your project where you registered your domain
 ![image](https://github.com/phydroxide/ensign/assets/31145228/887b7367-a297-48a7-8983-22bea4b0a893)
 
 

--- a/10_Certificates/README.md
+++ b/10_Certificates/README.md
@@ -89,5 +89,14 @@ gcloud container clusters get-credentials autopilot-cluster-1 --zone=us-central1
 ## Application Load Balancer
 I also need an [External Applcation Load Balancer](https://console.cloud.google.com/welcome?walkthrough_id=load-balancing--ext-https-load-balancer-ingress&_ga=2.244656581.1162373025.1719459190-2005931062.1714184856)
 
+## Certificates
+
+Load Balancers allow the creation of a certificate. You can Generate the CSR yourself, have an authority issue you a cert and import it, or let Google Manage it for you.
+
+You'll need to create a DNS record to validate the certificate challenge to prove you own the domain. 
+
+![image](https://github.com/phydroxide/ensign/assets/31145228/887b7367-a297-48a7-8983-22bea4b0a893)
+
+
 ## References
 [More Ingress Annotations](https://github.com/kelseyhightower/ingress-with-static-ip/blob/master/README.md)

--- a/10_Certificates/README.md
+++ b/10_Certificates/README.md
@@ -89,6 +89,15 @@ gcloud container clusters get-credentials autopilot-cluster-1 --zone=us-central1
 ## Application Load Balancer
 I also need an [External Applcation Load Balancer](https://console.cloud.google.com/welcome?walkthrough_id=load-balancing--ext-https-load-balancer-ingress&_ga=2.244656581.1162373025.1719459190-2005931062.1714184856)
 
+Part of this process includes:
+* Creating a Front End
+* Registering the IP in DNS
+* Connecting the Backend IPs, Ports, and Path Routes
+* Creating a Certificate
+* Validating the Certificate
+
+You can try the Backends that are created by Kubernetes Services, or point to the Ingress which is what I did. 
+
 ## Certificates
 
 Load Balancers allow the creation of a certificate. You can Generate the CSR yourself, have an authority issue you a cert and import it, or let Google Manage it for you.
@@ -106,6 +115,18 @@ It will ask you to create DNS authorization
 
 You'll set up the appropriate DNS record in your project where you registered your domain
 ![image](https://github.com/phydroxide/ensign/assets/31145228/887b7367-a297-48a7-8983-22bea4b0a893)
+
+## Victory
+
+If your site allows a visit at https://my.domainname.com then it's working!
+
+![image](https://github.com/phydroxide/ensign/assets/31145228/adda334b-af5d-4427-941a-cf6e8c9c18ef)
+
+[Secure Weather](https://myweather.phydroxide.com/server)
+[Alt Path 1](https://myweather.phydroxide.com/v1)
+[Alt Path 2](https://myweather.phydroxide.com/v2)
+
+![image](https://github.com/phydroxide/ensign/assets/31145228/1c8c5bec-3cb8-4477-910a-d021cc615f31)
 
 
 ## References

--- a/10_Certificates/README.md
+++ b/10_Certificates/README.md
@@ -1,0 +1,78 @@
+# Certificates
+
+## Start CLI environment
+From my Docker toolkit for students on Windows
+
+```
+docker run -it --privileged --name ensignwindows  -p 8080:8080 us-central1-docker.pkg.dev/ensign-421602/ensign-public/ensign-cli:windows /bin/bash
+```
+
+## Prepare GCP Project Environment 
+Login to GCP
+```
+gcloud auth login
+```
+
+
+I start with a clean project
+```
+gcloud projects create encert
+gcloud config set project ensigncert
+gcloud billing projects link ensigncert --billing-account=0101F3-XXXXX-ZZZZZ
+```
+
+Enable the Kubernetes API
+
+```
+gcloud services enable container.googleapis.com
+```
+
+## Create Cluster
+
+Creating an Autopilot Cluster makes me have to think less, but seems to take more time to provision. Autopilot clusters must be regional. 
+```
+gcloud container clusters create-auto autopilot-cluster-1 --region us-central1
+```
+
+It takes over 10 minutes for an autopilot cluster to finish provisioning. 
+
+
+## Now What?
+A lot of students struggled with what to do next. 
+The reading for 10.1 addresses how to [Use Google Managed Certificates](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs?hl=en&_ga=2.42614240.-437533536.1661485432)
+It says the HttpLoadBalancing add-on must be enabled. 
+
+Remember that Kubernetes is a technology leveraged by many Clouds, so there are many ways to accomplish this. Google's way directs you to enable the add-on, which is available through their gcloud cli.
+
+So I do a quick google search on "HttpLoadBalancing add-on kubernetes." Maybe I also add "GKE" to constrain the search results. Turns out I could have found this in their api documentation as well. 
+
+[Configure Ingress(https://cloud.google.com/kubernetes-engine/docs/how-to/load-balance-ingress) for external Application Load Balancers.
+
+
+
+## Patch Cluster with HttpLoadBalancing
+
+This takes some time. You can also specify it upon creation.
+```
+gcloud container clusters update autopilot-cluster-1 --update-addons=HttpLoadBalancing=ENABLED --region us-central1
+```
+
+Google tends to do a stellar job with their documentation. There are samples I copy and paste into my repository (see the files included in this repository's 'orchestration' directory). 
+
+## Reserve Static IP
+
+Both of the references above state I need to configure a [Static IP](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb#static_ip_addresses_for_https_load_balancers)
+
+
+
+## Apply Orchestrations
+
+Connect to the cluster that's been patched with HttpLoadBalancing
+
+```
+gcloud container clusters get-credentials autopilot-cluster-1 --zone=us-central1 
+
+```
+
+## Application Load Balancer
+I also need an [External Applcation Load Balancer](https://console.cloud.google.com/welcome?walkthrough_id=load-balancing--ext-https-load-balancer-ingress&_ga=2.244656581.1162373025.1719459190-2005931062.1714184856)

--- a/10_Certificates/README.md
+++ b/10_Certificates/README.md
@@ -63,15 +63,23 @@ Google tends to do a stellar job with their documentation. There are samples I c
 
 Both of the references above state I need to configure a [Static IP](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb#static_ip_addresses_for_https_load_balancers)
 
-
+```
+gcloud compute addresses create weather-ip --global --ip-version IPV4
+```
 
 ## Apply Orchestrations
+
+```
+git clone https://github.com/phydroxide/ensign.git
+cd ensign
+git checkout Certificates
+cd orchestrations
+```
 
 Connect to the cluster that's been patched with HttpLoadBalancing
 
 ```
 gcloud container clusters get-credentials autopilot-cluster-1 --zone=us-central1 
-
 ```
 
 ## Application Load Balancer

--- a/10_Certificates/README.md
+++ b/10_Certificates/README.md
@@ -97,6 +97,7 @@ You'll need to create a DNS record to validate the certificate challenge to prov
 ![image](https://github.com/phydroxide/ensign/assets/31145228/ac843d64-895f-4518-a26b-48423c0707a5)
 
 It will ask you to create DNS authorization
+
 ![image](https://github.com/phydroxide/ensign/assets/31145228/9e479fec-9b8f-4388-b06d-58050ac08680)
 
 

--- a/10_Certificates/README.md
+++ b/10_Certificates/README.md
@@ -76,6 +76,7 @@ git checkout Certificates
 cd orchestrations
 ```
 When you're done you'll have three three services pointing to my weather app and two demo apps, and an Ingress that can be configured to a Google Backend
+
 <img width="641" alt="image" src="https://github.com/phydroxide/ensign/assets/31145228/66b1d894-7584-4426-91d8-7ccf2a4fcb7f">
 
 
@@ -87,3 +88,6 @@ gcloud container clusters get-credentials autopilot-cluster-1 --zone=us-central1
 
 ## Application Load Balancer
 I also need an [External Applcation Load Balancer](https://console.cloud.google.com/welcome?walkthrough_id=load-balancing--ext-https-load-balancer-ingress&_ga=2.244656581.1162373025.1719459190-2005931062.1714184856)
+
+## References
+[More Ingress Annotations](https://github.com/kelseyhightower/ingress-with-static-ip/blob/master/README.md)

--- a/10_Certificates/README.md
+++ b/10_Certificates/README.md
@@ -75,6 +75,9 @@ cd ensign
 git checkout Certificates
 cd orchestrations
 ```
+When you're done you'll have three three services pointing to my weather app and two demo apps, and an Ingress that can be configured to a Google Backend
+<img width="641" alt="image" src="https://github.com/phydroxide/ensign/assets/31145228/66b1d894-7584-4426-91d8-7ccf2a4fcb7f">
+
 
 Connect to the cluster that's been patched with HttpLoadBalancing
 

--- a/10_Certificates/orchestration/hello-world-deployment-1.yaml
+++ b/10_Certificates/orchestration/hello-world-deployment-1.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world-deployment-1
+spec:
+  selector:
+    matchLabels:
+      greeting: hello
+      version: one
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        greeting: hello
+        version: one
+    spec:
+      containers:
+      - name: hello-app-1
+        image: "us-docker.pkg.dev/google-samples/containers/gke/hello-app:1.0"
+        env:
+        - name: "PORT"
+          value: "50000"

--- a/10_Certificates/orchestration/hello-world-deployment-2.yaml
+++ b/10_Certificates/orchestration/hello-world-deployment-2.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world-deployment-2
+spec:
+  selector:
+    matchLabels:
+      greeting: hello
+      version: two
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        greeting: hello
+        version: two
+    spec:
+      containers:
+      - name: hello-app-2
+        image: "us-docker.pkg.dev/google-samples/containers/gke/hello-app:2.0"
+        env:
+        - name: "PORT"
+          value: "8080"

--- a/10_Certificates/orchestration/hello-world-service-1.yaml
+++ b/10_Certificates/orchestration/hello-world-service-1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-world-1
+spec:
+  type: NodePort
+  selector:
+    greeting: hello
+    version: one
+  ports:
+  - protocol: TCP
+    port: 60000
+    targetPort: 50000 

--- a/10_Certificates/orchestration/hello-world-service-1.yaml
+++ b/10_Certificates/orchestration/hello-world-service-1.yaml
@@ -10,4 +10,4 @@ spec:
   ports:
   - protocol: TCP
     port: 60000
-    targetPort: 50000 
+    targetPort: 50000

--- a/10_Certificates/orchestration/hello-world-service-2.yaml
+++ b/10_Certificates/orchestration/hello-world-service-2.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: weather 
+  name: hello-world-2
 spec:
   type: NodePort
   selector:
-    greeting: weather 
-    version: one
+    greeting: hello
+    version: two
   ports:
   - protocol: TCP
-    port: 5000 
-    targetPort: 5555 
+    port: 80
+    targetPort: 8080

--- a/10_Certificates/orchestration/my-ingress.yaml
+++ b/10_Certificates/orchestration/my-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-ingress
+  annotations:
+    # If the class annotation is not specified it defaults to "gce".
+    kubernetes.io/ingress.class: "gce"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: hello-world-1
+            port:
+              number: 60000
+      - path: /v2
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: hello-world-2
+            port:
+              number: 80

--- a/10_Certificates/orchestration/my-ingress.yaml
+++ b/10_Certificates/orchestration/my-ingress.yaml
@@ -14,20 +14,20 @@ spec:
         pathType: ImplementationSpecific
         backend:
           service:
+            name: weather
+            port:
+              number: 5000 
+      - path: /v1
+        pathType: ImplementationSpecific
+        backend:
+          service:
             name: hello-world-1
             port:
-              number: 60000
+              number: 60000 
       - path: /v2
         pathType: ImplementationSpecific
         backend:
           service:
-            name: hello-world-2
+            name: hello-world-2 
             port:
-              number: 80
-      - path: /weather
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: weather 
-            port:
-              number: 5000 
+              number: 80 

--- a/10_Certificates/orchestration/my-ingress.yaml
+++ b/10_Certificates/orchestration/my-ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     # If the class annotation is not specified it defaults to "gce".
     kubernetes.io/ingress.class: "gce"
+    #kubernetes.io/ingress.global-static-ip-name: weather-ip 
 spec:
   rules:
   - http:

--- a/10_Certificates/orchestration/my-ingress.yaml
+++ b/10_Certificates/orchestration/my-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-ingress
   annotations:
     # If the class annotation is not specified it defaults to "gce".
-    kubernetes.io/ingress.class: "gce"
+    # kubernetes.io/ingress.class: "gce"
     #kubernetes.io/ingress.global-static-ip-name: weather-ip 
 spec:
   rules:
@@ -24,3 +24,10 @@ spec:
             name: hello-world-2
             port:
               number: 80
+      - path: /weather
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: weather 
+            port:
+              number: 5000 

--- a/10_Certificates/orchestration/weather-deployment.yaml
+++ b/10_Certificates/orchestration/weather-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world-deployment-1
+spec:
+  selector:
+    matchLabels:
+      greeting: hello
+      version: one
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        greeting: hello
+        version: one
+    spec:
+      containers:
+      - name: hello-app-1
+        image: "us-central1-docker.pkg.dev/ensign-421602/ensign-public/weather:extra"
+        env:
+        - name: "PORT"
+          value: "5555"

--- a/10_Certificates/orchestration/weather-deployment.yaml
+++ b/10_Certificates/orchestration/weather-deployment.yaml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hello-world-deployment-1
+  name: weather 
 spec:
   selector:
     matchLabels:
-      greeting: hello
+      greeting: weather 
       version: one
   replicas: 3
   template:

--- a/10_Certificates/orchestration/weather-deployment.yaml
+++ b/10_Certificates/orchestration/weather-deployment.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        greeting: hello
+        greeting: weather 
         version: one
     spec:
       containers:

--- a/10_Certificates/orchestration/weather-service.yaml
+++ b/10_Certificates/orchestration/weather-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-world-1
+spec:
+  type: NodePort
+  selector:
+    greeting: hello
+    version: one
+  ports:
+  - protocol: TCP
+    port: 60000
+    targetPort: 5555 

--- a/8_Lab9_Terraform/Docker/Dockerfile
+++ b/8_Lab9_Terraform/Docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM gcr.io/google.com/cloudsdktool/google-cloud-cli
-RUN apt-get update -y && apt-get install vim nano unzip -y && apt clean
+RUN apt-get update -y && apt-get install vim nano unzip dnsutils netcat-traditional iputils-ping net-tools ensurepip google-cloud-cli-cloud-build-local -y && apt clean
 RUN curl https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip -o tf.zip
 RUN unzip tf.zip
 RUN chmod 755 terraform
@@ -9,6 +9,7 @@ RUN chown cloudsdk:cloudsdk /app
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 RUN chmod 700 get_helm.sh 
 RUN ./get_helm.sh 
+RUN ln -s /usr/bin/python3 /usr/bin/python 
 USER cloudsdk
 #Running as root causes issues if you have code that generates keys based on the local user
 #Running as cloudsdk causes issues if you want to mount Docker container locally (docker run -v /var/run.docker.sock:/var/run/docker.sock

--- a/8_Lab9_Terraform/Docker/Dockerfile
+++ b/8_Lab9_Terraform/Docker/Dockerfile
@@ -9,9 +9,10 @@ RUN chown cloudsdk:cloudsdk /app
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 RUN chmod 700 get_helm.sh 
 RUN ./get_helm.sh 
-#USER cloudsdk
+USER cloudsdk
 #Running as root causes issues if you have code that generates keys based on the local user
 #Running as cloudsdk causes issues if you want to mount Docker container locally (docker run -v /var/run.docker.sock:/var/run/docker.sock
+#Windows can't mount docker socket so we do a separate build as cloudsdk
 WORKDIR /app 
 RUN git clone https://github.com/GoogleCloudPlatform/gke-security-scenarios-demo
 RUN sed -i 's/f1-micro/n1-standard-1/g' /app/gke-security-scenarios-demo/terraform/variables.tf

--- a/8_Lab9_Terraform/Docker/Dockerfile
+++ b/8_Lab9_Terraform/Docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM gcr.io/google.com/cloudsdktool/google-cloud-cli
-RUN apt-get update -y && apt-get install vim nano unzip dnsutils netcat-traditional iputils-ping net-tools ensurepip google-cloud-cli-cloud-build-local -y && apt clean
+RUN apt-get update -y && apt-get install vim nano unzip dnsutils netcat-traditional iputils-ping net-tools python3-venv google-cloud-cli-cloud-build-local -y && apt clean
 RUN curl https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip -o tf.zip
 RUN unzip tf.zip
 RUN chmod 755 terraform

--- a/8_Lab9_Terraform/Docker/Dockerfile.root
+++ b/8_Lab9_Terraform/Docker/Dockerfile.root
@@ -1,0 +1,21 @@
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli
+RUN apt-get update -y && apt-get install vim nano unzip dnsutils netcat-traditional iputils-ping net-tools python3-venv google-cloud-cli-cloud-build-local -y && apt clean
+RUN curl https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip -o tf.zip
+RUN unzip tf.zip
+RUN chmod 755 terraform
+RUN mv terraform /usr/local/bin
+RUN mkdir /app 
+RUN chown cloudsdk:cloudsdk /app 
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+RUN chmod 700 get_helm.sh 
+RUN ./get_helm.sh 
+RUN ln -s /usr/bin/python3 /usr/bin/python 
+#USER cloudsdk
+#Running as root causes issues if you have code that generates keys based on the local user
+#Running as cloudsdk causes issues if you want to mount Docker container locally (docker run -v /var/run.docker.sock:/var/run/docker.sock
+#Windows can't mount docker socket so we do a separate build as cloudsdk
+WORKDIR /app 
+RUN git clone https://github.com/GoogleCloudPlatform/gke-security-scenarios-demo
+RUN sed -i 's/f1-micro/n1-standard-1/g' /app/gke-security-scenarios-demo/terraform/variables.tf
+COPY ./enable-apis.sh /app/gke-security-scenarios-demo/scripts/
+WORKDIR /home/cloudsdk

--- a/9_Prep_Jenkins_GCP/README.md
+++ b/9_Prep_Jenkins_GCP/README.md
@@ -21,6 +21,18 @@ docker run -it --privileged \
   /bin/bash
 ```
 
+On Windows you cannot map the docker socket and therefore do not need --privileged. 
+I've rebuilt the container for windows using the cloudsdk user instead of root. 
+
+```
+docker run -it --privileged --name ensigncli \
+  -v /Users/phydroxide/PHYDROXIDE/:/home/cloudsdk \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -p 8080:8080 \
+   us-central1-docker.pkg.dev/ensign-421602/ensign-public/ensign-cli:windows \
+  /bin/bash
+```
+
 ### Parameters explained
 `docker` is the command-line binary you're able to run by having installed Docker Desktop.
 
@@ -37,7 +49,9 @@ docker run -it --privileged \
 /var/run/docker.sock on the right side of the ':' is where you've mounted docker's socket within the container so you can run docker within
 us-central1-docker.pkg.dev: This is GCP's artifact repository that I've enabled in my project in the us-central region.
 
-You could also add here `-v Some\Local\Path\:/root` so you have access to the development files in your home directory. 
+You could also add here `-v Some\Local\Path\:/root` or `-v /c/user/path:/home/cloudsdk` so you have access to the development files in your home directory. 
+
+`-p` maps a port from your host into the docker runtime so that when you do things like kubectl port forwarding, that port comes all the way up to the workstation hosting Docker's virtual environment.
 
 /ensign-421602/: GCP's artifact repository is multi-tenant. This is my project name so you can reach my container registry from that URL.
 


### PR DESCRIPTION
Students are wondering how to create web applications that include loadbalancers with https certificates. 

One way to do this is with GCP's Load Balancing Services and Certificate management.

And why wouldn't you? Only if there are cost constraints, which there sometimes are, would I go through the hassle of trying to manage my own setup. 

![image](https://github.com/phydroxide/ensign/assets/31145228/f4f2ddb6-9568-4d06-a082-3228c84a51ac)

![image](https://github.com/phydroxide/ensign/assets/31145228/66e092bf-1da6-47d6-b4d2-2e44d4222741)

Be advised that if you use a regional instead of global loadbalancer, Google-Managed certs are not supported. You'll need to manage your own certificates. If anybody has interest in that I can show you how to create your own Certificate Signing Request manually. 

Otherwise you can use the certificate management Service in Google. Use the same project your domain resides in as Google may use that to validate your certs. 
![image](https://github.com/phydroxide/ensign/assets/31145228/e4a02870-31fe-442f-a3b0-9da8d225fad6)




